### PR TITLE
Add ES6 config to be used by Vue 3 apps

### DIFF
--- a/modern-es6-only.js
+++ b/modern-es6-only.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = [
+	'last 2 Chrome versions',
+	'last 2 Firefox versions',
+	'last 2 Opera versions',
+	'last 2 Edge versions',
+	'Safari >= 10',
+	'iOS >= 10',
+	'last 2 Android versions'
+];


### PR DESCRIPTION
Vue 3 in particular _requires_ the Proxy object, so trying to transpile/polyfill for browsers that do not support Proxy is pointless as the Proxy object cannot be polyfilled/transpiled.

This config is probably somewhat temporary until [T178356 - Raising Grad A JavaScript requirement from ES5 to ES6 (ES2015)](https://phabricator.wikimedia.org/T178356) is implemented.

See also:
https://caniuse.com/es6
https://caniuse.com/proxy