### PR TITLE
basic: Bump requirements for 2022

### DIFF
--- a/basic.js
+++ b/basic.js
@@ -2,11 +2,11 @@
 
 module.exports = [
 	'Chrome >= 31',
-	'Firefox >= 27',
+	'Firefox >= 39',
 	'Opera >= 18',
 	'Edge >= 12',
-	'IE >= 9',
+	'IE >= 11',
 	'Safari >= 9.1',
 	'iOS >= 9',
-	'Android >= 4.3'
+	'Android >= 5'
 ];


### PR DESCRIPTION
* Internet Explorer	9-10	→ 11
* Firefox		27+	→ 39+
* Android		4.3+	→ 5+