### PR TITLE
Drop IE11, bump Safari to 11+, change "last 2 versions" to "last 3 years", and Firefox ESR

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For example, when configuring [@babel/preset-env](https://babeljs.io/docs/en/bab
 4. To override or slightly adapt one of the available Browserslist configurations, modern or basic, add your overrides to the list. Exemplified with `.browerslistrc`:
 ```
 extends browserslist-config-wikimedia/basic
-not IE <= 10
+not Android <= 8
 ```
 
 

--- a/modern-es6-only.js
+++ b/modern-es6-only.js
@@ -1,0 +1,3 @@
+'use strict';
+
+return require( './modern' );

--- a/modern-es6-only.json
+++ b/modern-es6-only.json
@@ -1,9 +1,0 @@
-[
-	"last 2 Chrome versions",
-	"last 2 Firefox versions",
-	"last 2 Opera versions",
-	"last 2 Edge versions",
-	"Safari >= 10",
-	"iOS >= 10",
-	"last 2 Android versions"
-]

--- a/modern.json
+++ b/modern.json
@@ -1,10 +1,9 @@
 [
-	"last 2 Chrome versions",
-	"last 2 Firefox versions",
-	"last 2 Opera versions",
-	"last 2 Edge versions",
-	"IE >= 11",
-	"Safari >= 9.1",
-	"iOS >= 9",
+	"Last 3 years and Chrome > 0",
+	"Last 3 years and Opera > 0",
+	"Last 3 years and Edge > 0",
+	"Firefox >= 91",
+	"Safari >= 11",
+	"iOS >= 11",
 	"Android >= 5"
 ]


### PR DESCRIPTION
"Last 3 years" requires some strange syntax to also limit
to a specific browser.

For "last 2 ESR" (which doesn't work) just specify
Firefox >= 91 and we can update when the next ESR comes out.

"modern-es6-only" is now deprecated so redirects to "modern".
