### PR TITLE
Fix deprecated modern-es6-only list

### DIFF
--- a/modern-es6-only.js
+++ b/modern-es6-only.js
@@ -1,3 +1,3 @@
 'use strict';
 
-return require( './modern' );
+module.exports = require( './modern' );


### PR DESCRIPTION
Use module.exports =, instead of return.
